### PR TITLE
add a new paper: LETS Forecast: Learning Embedology for Time Series F…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ List of state of the art papers, code, and other resources focus on time series 
 
 ## Papers
 
+### 2025
+
+- [LETS Forecast: Learning Embedology for Time Series Forecasting](https://abrarmajeedi.github.io/deep_edm/) `ICML 2025`
+  - [[code](https://github.com/abrarmajeedi/DeepEDM)]
+
 ### 2024 
 
 - [TimeMachine: A Time Series is Worth 4 Mambas for Long-term Forecasting](https://arxiv.org/pdf/2403.09898.pdf) `Arxiv`


### PR DESCRIPTION
This PR adds an ICML 2025 paper, `LETS Forecast`, to the list of papers.

> DeepEDM (LETS Forecast) integrates empirical dynamic modeling (EDM) with deep learning by learning a latent space from time-delayed embeddings, then applying kernel regression with softmax attention to robustly approximate nonlinear system dynamics, enabling accurate and noise-resistant time series forecasting in an end-to-end differentiable manner.
