### PR TITLE
Adding Chronos 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ List of state of the art papers, code, and other resources focus on time series 
 ## Papers
 
 ### 2025
+- [Chronos-2: From Univariate to Universal Forecasting](https://www.arxiv.org/abs/2510.15821) `Arxiv`
+  - [[code](https://github.com/amazon-science/chronos-forecasting)]
+  - [[model card](https://huggingface.co/amazon/chronos-2)]
 
 - [LETS Forecast: Learning Embedology for Time Series Forecasting](https://abrarmajeedi.github.io/deep_edm/) `ICML 2025`
   - [[code](https://github.com/abrarmajeedi/DeepEDM)]


### PR DESCRIPTION
Adding Chronos 2

Chronos-2 is a pretrained model capable of handling univariate, multivariate, and covariate-informed forecasting tasks in a zero-shot manner.